### PR TITLE
feat: add artifacthub-repo.yml file

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+repositoryID: 
+owners:
+  - name: Cole
+    email: cole@airbyte.io
+  - name: Angel
+    email: angel@airbyte.io


### PR DESCRIPTION
- adding this to allow us to mark our charts as official in artifacthub
    - required per [the artifacthub docs](https://artifacthub.io/docs/topics/repositories/#official-status)